### PR TITLE
Improve Windows support

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -30,15 +30,33 @@ Vagrant.configure("2") do |config|
 
   config.vm.network :forwarded_port, guest: 80, host: 6060
 
-  if os == :windows
-    config.vm.synced_folder "OTM2", "/usr/local/otm/app", type: "rsync", rsync__exclude: ".git/, node_modules, opentreemap/opentreemap/local_settings.py"
-    config.vm.synced_folder "OTM2-tiler", "/usr/local/tiler", type: "rsync", rsync__exclude: ".git/, node_modules, settings.json"
-    config.vm.synced_folder "ecobenefits", "/usr/local/ecoservice", type: "rsync", rsync__exclude: ".git/"
-    config.vm.synced_folder ".", "/vagrant", type: "rsync", rsync__exclude: ".git/"
-  else
+  if os != :windows
     config.vm.synced_folder "OTM2", "/usr/local/otm/app"
     config.vm.synced_folder "OTM2-tiler", "/usr/local/tiler"
     config.vm.synced_folder "ecobenefits", "/usr/local/ecoservice"    
+
+  else
+    # For Windows hosts, work around limitation that symbolic links don't work in shared folders
+    if not File.exist?('.vagrant/machines/default/virtualbox/id')
+      # VM not set up yet -- rsync everything
+      config.vm.synced_folder ".", "/vagrant", type: "rsync", rsync__exclude: ".git/"
+      config.vm.synced_folder "OTM2", "/usr/local/otm/app", type: "rsync", rsync__exclude: [".git/", "node_modules", "opentreemap/opentreemap/local_settings.py"]
+
+    else
+      # VM already set up.
+      # Exclude "configs" folder to avoid clobbering nginx configuration.
+      config.vm.synced_folder ".", "/vagrant", type: "rsync", rsync__exclude: [".git/", "configs/"]
+
+      # Use a true shared folder for "opentreemap" (for convenience) (works because it uses no symlinks)
+      config.vm.synced_folder "OTM2/opentreemap", "/usr/local/otm/app/opentreemap"
+      if not File.exist?('OTM2/opentreemap/opentreemap/local_settings.py')
+        # local_settings.py was created on the guest, but we need to create it on the host since we're sharing its folder.
+        FileUtils.cp('configs/usr/local/otm/app/opentreemap/opentreemap/local_settings.py', 'OTM2/opentreemap/opentreemap')
+      end
+    end
+
+    config.vm.synced_folder "OTM2-tiler", "/usr/local/tiler", type: "rsync", rsync__exclude: [".git/", "node_modules", "settings.json"]
+    config.vm.synced_folder "ecobenefits", "/usr/local/ecoservice", type: "rsync", rsync__exclude: ".git/"
   end
 
   config.vm.provision :shell, :path => "OTM2/scripts/bootstrap.sh"

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -89,6 +89,7 @@ npm install
 # nginx
 apt-get install -yq nginx
 rm /etc/nginx/sites-enabled/default
+ln -s /etc/nginx/sites-available/otm.conf /etc/nginx/sites-enabled/otm
 
 initctl reload-configuration
 

--- a/configs/etc/nginx/sites-enabled/otm
+++ b/configs/etc/nginx/sites-enabled/otm
@@ -1,1 +1,0 @@
-../sites-available/otm.conf


### PR DESCRIPTION
- Symlink `/etc/nginx/sites-enabled/otm` directly rather than via `configs`
- Use correct syntax for rsync excluded folders
- On subsequent `vagrant up`s:
  - avoid clobbering nginx configuration by ignoring `config` directory when rsyncing `.`
  - use true (non-rsync'd) shared folder (and copy in `local_settings.py`)
