### PR TITLE
modify ecoservice directory name in config file

### DIFF
--- a/configs/usr/local/ecoservice/config.gcfg
+++ b/configs/usr/local/ecoservice/config.gcfg
@@ -9,4 +9,4 @@ host=127.0.0.1
 port=13000
 
 [data]
-path=/usr/local/ecobenefits/data/
+path=/usr/local/ecoservice/data/


### PR DESCRIPTION
Changing this will make it reflect the reality of the path that bootstrap.sh actually sets up.
