### PR TITLE
Resolve breaking issues and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,22 @@
 otm-vagrant
 ===========
 
-#WARNING
+Vagrant files and scripts for setting up a local testing and development instance of OpenTreeMap (OTM)
 
-**This repository does not currently work with recent versions of OTM2
-which packages client-side assets with Webpack instead of Grunt and Browserfify.**
-
----
-
-
-Vagrant files and scripts for setting up a local testing and development instance of OTM2
-
-__NOTE:__ This repository is intended _only_ for development and testing.  It is not intended for setting up a production OTM2 server.
+__NOTE:__ This repository is intended _only_ for development and testing.  It is not intended for setting up a production OTM server.
 
 To get started, do the following steps:
 
  - Install [Vagrant](http://www.vagrantup.com/) and [VirtualBox](https://www.virtualbox.org/)
  - Clone this repository
+ - Create a [Google Maps API key](https://developers.google.com/maps/documentation/javascript/get-api-key) and add a line to `configs/usr/local/otm/app/opentreemap/opentreemap/settings/local_settings.py`:
+```python
+GOOGLE_MAPS_API_KEY = 'the-api-key-you-just-created'
+```
  - Run the script `get-repos.sh`
  - Run the command `vagrant up`
 
-This will give you a working installation of OTM2, but without any maps.
+This will give you a working installation of OTM, but without any maps.
 
 To create a map do the following steps:
 

--- a/configs/usr/local/otm/app/opentreemap/opentreemap/settings/local_settings.py
+++ b/configs/usr/local/otm/app/opentreemap/opentreemap/settings/local_settings.py
@@ -19,3 +19,5 @@ CELERY_RESULT_BACKEND = 'redis://localhost:6379/'
 
 EMAIL_BACKEND = 'django.core.mail.backends.filebased.EmailBackend'
 EMAIL_FILE_PATH = '/usr/local/otm/emails'
+
+GOOGLE_MAPS_API_KEY = 'put-your-api-key-here'


### PR DESCRIPTION
* Package client-side assets using `webpack` instead of `grunt`
* Use updated URL for `go` distribution, and updated version 1.6.3
* Remove unnecessary library references
* Update README with instructions for configuring a Google Maps API key
* Make media folder world-writable so `celeryd` can write to it

Connects #41
Connects #42
Connects #43
Connects #45