### PR TITLE
Update node version used for webpack to 4.8.0 and pip version to 9.0.*

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -20,7 +20,12 @@ service celeryd stop || true
 apt-get install -yq redis-server
 
 # Django + GeoDjango
-apt-get install -yq gettext libgeos-dev libproj-dev libgdal1-dev build-essential python-pip python-dev
+apt-get install -yq gettext libgeos-dev libproj-dev libgdal1-dev build-essential python-dev
+
+# pip
+cd /tmp
+wget https://bootstrap.pypa.io/get-pip.py
+python get-pip.py pip==9.0.*
 
 # DB
 apt-get install -yq postgresql postgresql-server-dev-9.3 postgresql-contrib postgresql-9.3-postgis-2.1

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -56,7 +56,7 @@ chmod 777 /usr/local/otm/media
 # Use newer version of nodejs for bundling assets
 apt-get install -yq npm
 npm install -g nave
-NODE_VERSION_FOR_WEBPACK=0.12.15
+NODE_VERSION_FOR_WEBPACK=4.8.0
 nave usemain $NODE_VERSION_FOR_WEBPACK
 
 # Bundle JS and CSS via webpack


### PR DESCRIPTION
At least one dependency of the webpack module no longer supports node 0.12.15.

---

##### Testing 

On the master branch, `npm run build` fails with

```
==> default: ERROR in ./assets/css/sass/main.scss
==> default: Module build failed: /usr/local/otm/app/node_modules/postcss-loader/node_modules/loader-utils/lib/index.js:3
==> default: const getOptions = require("./getOptions");
==> default: ^^^^^
==> default: SyntaxError: Use of const in strict mode.
```

On this branch, starting with no VM, it should be possible to successfully run through the instructions in README.md.

---

Connects to https://github.com/azavea/trees-team/issues/117