### PR TITLE
Update to work with latest otm-core & otm-tiler changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,8 @@ To get started, do the following steps:
 
  - Install [Vagrant](http://www.vagrantup.com/) and [VirtualBox](https://www.virtualbox.org/)
  - Clone this repository
- - Create a [Google Maps API key](https://developers.google.com/maps/documentation/javascript/get-api-key) and add a line to `configs/usr/local/otm/app/opentreemap/opentreemap/settings/local_settings.py`:
-```python
-GOOGLE_MAPS_API_KEY = 'the-api-key-you-just-created'
-```
+ - Create a [Google Maps API key](https://developers.google.com/maps/documentation/javascript/get-api-key) and replace the `GOOGLE_MAPS_KEY` in  `configs/etc/init/otm-unicorn.conf` with the key you created
+ - Create a [Esri API credentials](https://developers.arcgis.com/documentation/core-concepts/security-and-authentication/accessing-arcgis-online-services/) and replace the `ESRI_CLIENT_ID` and `ESRI_CLIENT_SECRET` in  `configs/etc/init/otm-unicorn.conf` with the credentials you created
  - Run the script `get-repos.sh`
  - Run the command `vagrant up`
 

--- a/configs/etc/init/otm-unicorn.conf
+++ b/configs/etc/init/otm-unicorn.conf
@@ -8,6 +8,10 @@ respawn limit 50 5
 
 kill timeout 5
 
+env ESRI_CLIENT_ID=your_client_id
+env ESRI_CLIENT_SECRET=your_client_secret
+env GOOGLE_MAPS_KEY=your_google_maps_key
+
 chdir /usr/local/otm/app/opentreemap
 
 exec gunicorn -w 2 -b "0.0.0.0:12000" opentreemap.wsgi:application

--- a/configs/usr/local/otm/app/opentreemap/opentreemap/settings/local_settings.py
+++ b/configs/usr/local/otm/app/opentreemap/opentreemap/settings/local_settings.py
@@ -19,5 +19,3 @@ CELERY_RESULT_BACKEND = 'redis://localhost:6379/'
 
 EMAIL_BACKEND = 'django.core.mail.backends.filebased.EmailBackend'
 EMAIL_FILE_PATH = '/usr/local/otm/emails'
-
-GOOGLE_MAPS_API_KEY = 'put-your-api-key-here'

--- a/test.sh
+++ b/test.sh
@@ -8,14 +8,16 @@ cd /usr/local/ecoservice
 godep go test eco/*
 
 cd /usr/local/otm/app/
-grunt check
+yarn run check
 
-export DISPLAY=":99.0"
-Xvfb $DISPLAY 2>/dev/null >/dev/null &
-testem ci
+yarn run test
 
 flake8 --exclude migrations,opentreemap/settings/local_settings.py opentreemap
-# Need to run grunt before running the UI tests
-grunt
-python opentreemap/manage.py test
-python opentreemap/manage.py test  -p 'uitest*.py'
+# Need to build assets before running the UI tests
+python opentreemap/manage.py collectstatic_js_reverse
+yarn run build
+python opentreemap/manage.py collectstatic --noinput
+
+cd opentreemap
+python manage.py test
+xvfb-run python manage.py test  -p 'uitest*.py'

--- a/test.sh
+++ b/test.sh
@@ -10,7 +10,7 @@ godep go test eco/*
 cd /usr/local/otm/app/
 yarn run check
 
-yarn run test
+xvfb-run yarn run test
 
 flake8 --exclude migrations,opentreemap/settings/local_settings.py opentreemap
 # Need to build assets before running the UI tests


### PR DESCRIPTION
Changes:
 - Switch to Node.js 6
 - Install newly required otm-tiler system dependencies
 - Use yarn for both otm-tiler & otm-core
 - Add documentation for Esri API keys
 - Switch to pinned version of firefox to avoid firefox/selenium conflicts

Testing:
Follow the directions in the README to create a new `otm-vagrant` VM.

Connects to #53
Connects to #49